### PR TITLE
Font changed to Fira Mono and size to 13pt

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 
     <link type="text/css" rel="stylesheet" href="./css/bootstrap.css">
     <link type="text/css" rel="stylesheet" href="./css/main.css">
+    // Fira Mono imported
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 
 </head>

--- a/index.html
+++ b/index.html
@@ -128,6 +128,10 @@
     $("#editor").css("display", "block");
     editor.setTheme("ace/theme/monokai");
     editor.getSession().setMode("ace/mode/javascript");
+    editor.setOptions({
+      fontFamily: "Fira Mono",
+      fontSize: "13pt"
+   });
 </script>
 
 


### PR DESCRIPTION
The editor font has been changed to Fira Mono and size increased to 13pt however Fira Mono is not being supported i guess in the Ace editor as the cursor has some problem, should I revert back to some compatible font family? @championswimmer 